### PR TITLE
remove trailing slash on void elements

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -3,34 +3,34 @@
 <title>{{ page.title }}</title>
 {% if include.content == "404" %}
     <!-- The "robots" metadata disallowing page indexing is manually added to the 404 page since accessing it directly returns HTTP Status Code 200 -->
-    <meta name="robots" content="noindex, nofollow" />
+    <meta name="robots" content="noindex, nofollow">
 {% endif %}
-<meta name="description" content="{{ page.description }}"/>
+<meta name="description" content="{{ page.description }}">
 
-<meta name="theme-color" content="#241f31"/>
-<meta name="color-scheme" content="dark light"/>
+<meta name="theme-color" content="#241f31">
+<meta name="color-scheme" content="dark light">
 
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 
-<meta property="og:title" content="{{ page.title }}"/>
-<meta property="og:description" content="{{ page.description }}"/>
-<meta property="og:type" content="website"/>
-<meta property="og:image" content="https://secureblue.dev/assets/icons/opengraph.png"/>
-<meta property="og:image:width" content="512"/>
-<meta property="og:image:height" content="512"/>
-<meta property="og:image:alt" content="secureblue logo"/>
-<meta property="og:site_name" content="secureblue"/>
-<meta property="og:url" content="https://secureblue.dev/{{ include.content }}"/>
+<meta property="og:title" content="{{ page.title }}">
+<meta property="og:description" content="{{ page.description }}">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://secureblue.dev/assets/icons/opengraph.png">
+<meta property="og:image:width" content="512">
+<meta property="og:image:height" content="512">
+<meta property="og:image:alt" content="secureblue logo">
+<meta property="og:site_name" content="secureblue">
+<meta property="og:url" content="https://secureblue.dev/{{ include.content }}">
 
-<link rel="canonical" href="https://secureblue.dev/{{ include.content }}"/>
+<link rel="canonical" href="https://secureblue.dev/{{ include.content }}">
 
-<link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
-<link rel="shortcut icon" href="/assets/icons/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png" />
-<meta name="apple-mobile-web-app-title" content="secureblue" />
-<link rel="mask-icon" href="/assets/icons/mask-icon.svg" color="#096b9f"/>
+<link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg">
+<link rel="shortcut icon" href="/assets/icons/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
+<meta name="apple-mobile-web-app-title" content="secureblue">
+<link rel="mask-icon" href="/assets/icons/mask-icon.svg" color="#096b9f">
 
-<link rel="stylesheet" href="/assets/main.css"/>
+<link rel="stylesheet" href="/assets/main.css">
 
-<link rel="manifest" href="/assets/manifest.webmanifest" />
+<link rel="manifest" href="/assets/manifest.webmanifest">


### PR DESCRIPTION
Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).